### PR TITLE
fix incompatible dependency version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 zope
-attrs>=17.4.0
+attrs~=23.0
 pycryptodome>=3.6.1
 base58check>=1.0.1
 zope.interface>=4.4.3

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
         'https://github.com/nobitex/coinaddrvalid/tarball/v%s' % version),
     license='MIT',
     install_requires=[
-        'attrs>=17.4.0',
+        'attrs~=23.0',
         'pycryptodome>=3.6.1',
         'base58check>=1.0.1',
         'zope.interface>=4.4.3',
@@ -67,6 +67,7 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3 :: Only',
         'Topic :: Internet :: WWW/HTTP',
         'Topic :: Software Development',


### PR DESCRIPTION
By default attrs in version 24.2.0 has been installed. This version has some breaking changes and there was compatibility issue in validation.py.

```
  File "/home/norbert/.local/share/uv/python/cpython-3.11.9-linux-x86_64-gnu/lib/python3.11/unittest/loader.py", line 362, in _get_module_from_name
    __import__(name)
  File "/home/norbert/Dev/coinaddrvalidator/tests/test_validation.py", line 6, in <module>
    from coinaddrvalidator.validation import (
  File "/home/norbert/Dev/coinaddrvalidator/tests/../coinaddrvalidator/__init__.py", line 21, in <module>
    from . import interfaces, currency, validation
  File "/home/norbert/Dev/coinaddrvalidator/tests/../coinaddrvalidator/validation.py", line 53, in <module>
    class ValidatorBase(metaclass=ValidatorMeta):
  File "/home/norbert/Dev/coinaddrvalidator/tests/../coinaddrvalidator/validation.py", line 62, in ValidatorBase
    attr.validators.provides(IValidationRequest)
    ^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: module 'attr.validators' has no attribute 'provides'
```